### PR TITLE
use distro-provided icecc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,22 +6,9 @@ ENV XCODE_VERSION=$HOST_XCODE_VERSION
 
 LABEL maintainer="Tor Arne Vestbø <torarnv@gmail.com>"
 
-ARG ICECREAM_REPO="https://github.com/icecc/icecream.git"
-
-# Build latest Icecream from source
 RUN apt-get update && apt-get -q install -y \
-		autotools-dev \
-		automake \
-		libtool \
-		liblzo2-dev \
-		libzstd-dev \
-		libarchive-dev && \
-	git clone --depth 1 --single-branch $ICECREAM_REPO /src/icecream && \
-	cd /src/icecream && \
-	./autogen.sh && \
-	./configure --with-libcap-ng=no --without-man && \
-	make && \
-	make install
+		icecc \
+		make
 
 VOLUME /out
 WORKDIR /out


### PR DESCRIPTION
with xcode14/swift5.7 icecc doesn't want to build from sources:
```
checking for lzo1x_1_compress in -llzo2... no
configure: error: Could not find lzo2 library - please install lzo-devel
```

despite liblzo2-dev being installed, it is not detected. however it seems to be possible to use vanilla icecc these days